### PR TITLE
chore: bump scDataLoader floor to 2.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "torchmetrics>=1.6.0",
     "torchdata>=0.7.1",
     "lamindb[gcp]==2.1.1",
-    "scDataLoader>=2.1.1",
+    "scDataLoader>=2.1.3",
     "simpler_flash>=1.3.5",
     "GRnnData>=1.3.2",
     "BenGRN>=1.3.2",


### PR DESCRIPTION
Picks up the freshly released scdataloader 2.1.3 (https://pypi.org/project/scdataloader/2.1.3/):
- scipy>=1.15 compat in `additional_postprocess` (jkobject/scDataLoader#32, #34)
- compound ontology id handling in `translate()` (jkobject/scDataLoader#33)
- `lamin init --modules bionty` docs (lamindb 2.1.x)

No code changes needed on the scPRINT-2 side — both fixes were transparent.