### PR TITLE
fix: align package license metadata with GPL-3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "scPRINT-2 is a Large Cell Model for Gene Network Inference, Denoi
 authors = [
     {name = "jeremie kalfon", email = "jkobject@gmail.com"}
 ]
-license = "MIT"
+license = "GPL-3.0-or-later"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"
 keywords = ["scRNAseq", "transformer", "GRN", "gene regulatory network", "scPRINT-2", "large cell model", "foundation model"]


### PR DESCRIPTION
## Summary

- align the package's SPDX license metadata with the repository `LICENSE`
- use `GPL-3.0-or-later`, matching the existing scverse ecosystem metadata

The repository license was deliberately changed from MIT to GPLv3 in commit `399b484` (2025-11-19), while the older `pyproject.toml` value remained unchanged. The published 1.0.3 wheel consequently embeds the GPL text while declaring `License-Expression: MIT`. This one-line correction makes future distributions coherent without changing the license text or unrelated documentation.

## Validation

- `uv build`
- inspected built wheel: `License-Expression: GPL-3.0-or-later`, bundled GNU GPL text with the “or later” clause
- inspected built sdist: matching `pyproject.toml` and `LICENSE`
- `git diff --check`

Follow-up to the license review blocker on scverse/ecosystem-packages#326.
